### PR TITLE
Fix minor breaking changes from WPILib

### DIFF
--- a/src/test/java/com/spartronics4915/lib/subsystems/estimator/DrivetrainEstimatorTest.java
+++ b/src/test/java/com/spartronics4915/lib/subsystems/estimator/DrivetrainEstimatorTest.java
@@ -18,7 +18,7 @@ import org.knowm.xchart.XYChartBuilder;
 
 import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
-import edu.wpi.first.wpilibj.math.StateSpaceUtils;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
 import edu.wpi.first.wpiutil.math.MatBuilder;
 import edu.wpi.first.wpiutil.math.Matrix;
 import edu.wpi.first.wpiutil.math.Nat;
@@ -87,7 +87,7 @@ public class DrivetrainEstimatorTest
                     groundtruthState.poseMeters.getRotation().getRadians()
                         - lastPose.getRotation().getRadians());
             }
-            u = u.plus(StateSpaceUtils.makeWhiteNoiseVector(Nat.N3(),
+            u = u.plus(StateSpaceUtil.makeWhiteNoiseVector(Nat.N3(),
                 new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.002, 0.002, 0.001)));
             lastPose = groundtruthState.poseMeters;
 

--- a/vendordeps/WPILibStateSpace.json
+++ b/vendordeps/WPILibStateSpace.json
@@ -1,12 +1,12 @@
 {
-    "fileName": "wpilibStateSpace.json",
-    "name": "wpilibStateSpace",
+    "fileName": "WPILibStateSpace.json",
+    "name": "WPILibStateSpace",
     "version": "2020.2.5",
     "uuid": "82b203c8-9ae1-4031-914c-20460fa41cb1",
     "mavenUrls": [
-        "https://maven.meshnet0.com/releases/"
+        "https://maven.0x778.tk/"
     ],
-    "jsonUrl": "https://maven.meshnet0.com/wpilibStateSpace-latest.json",
+    "jsonUrl": "https://maven.0x778.tk/edu/wpi/first/wpilibStateSpace/wpilibStateSpace.json",
     "cppDependencies": [
         {
             "groupId": "edu.wpi.first.wpilibStateSpace",
@@ -62,4 +62,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
@pietroglyph Our tests fail with the following error - do you know if this is a me problem or something in the code?

```java
com.spartronics4915.lib.subsystems.estimator.DrivetrainEstimatorTest > testEstimator() FAILED
    java.lang.UnsatisfiedLinkError: 'void edu.wpi.first.wpiutil.math.DrakeJNI.discreteAlgebraicRiccatiEquation(double[], double[], double[], double[], int, int, double[])'
        at edu.wpi.first.wpiutil.math.DrakeJNI.discreteAlgebraicRiccatiEquation(Native Method)
        at edu.wpi.first.wpiutil.math.Drake.discreteAlgebraicRiccatiEquation(Drake.java:32)
        at edu.wpi.first.wpiutil.math.Drake.discreteAlgebraicRiccatiEquation(Drake.java:53)
        at edu.wpi.first.wpilibj.estimator.ExtendedKalmanFilter.<init>(ExtendedKalmanFilter.java:96)
        at com.spartronics4915.lib.subsystems.estimator.DrivetrainEstimator.<init>(DrivetrainEstimator.java:56)
        at com.spartronics4915.lib.subsystems.estimator.DrivetrainEstimatorTest.testEstimator(DrivetrainEstimatorTest.java:36)
```